### PR TITLE
add link to overlay containing the ebuild

### DIFF
--- a/docs/platforms-and-packages.md
+++ b/docs/platforms-and-packages.md
@@ -10,4 +10,4 @@ Gopass-ui is available for the following platforms:
 For Linux the following packages are provided:
 * .deb (download [here](https://github.com/codecentric/gopass-ui/releases/latest))
 * .rpm (download [here](https://github.com/codecentric/gopass-ui/releases/latest))
-* Gentoo: `emerge app-admin/gopass-ui` (thanks [@danielcb](https://github.com/danielcb))
+* Gentoo: `emerge app-admin/gopass-ui` ([gentoo overlay](https://gitlab.awesome-it.de/overlays/awesome), thanks [@danielcb](https://github.com/danielcb))


### PR DESCRIPTION
Gentoo users can probably find it via google or in the [overlay list](https://overlays.gentoo.org/), but it might be easier to just link to the overlay.