### PR TITLE
Quit application on mainWindow 'closed'

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -116,6 +116,11 @@ const setup = async () => {
     const settings = getUserSettings()
 
     mainWindow = createMainWindow()
+
+    mainWindow.on('closed', () => {
+        app.quit()
+    })
+
     searchWindow = createSearchWindow(false)
 
     setGlobalShortcut(settings.searchShortcut)


### PR DESCRIPTION
For some reason, the existing on 'window-all-closed' is never
entered on linux systems.