### PR TITLE
Fix password copying

### DIFF
--- a/src/renderer/secrets/Gopass.ts
+++ b/src/renderer/secrets/Gopass.ts
@@ -20,7 +20,7 @@ export default class Gopass {
     public static executionId = 1
 
     public static async copy(key: string): Promise<string> {
-        return Gopass.execute(`show "${escapeShellValue(key)}" -c`)
+        return Gopass.execute(`show -c "${escapeShellValue(key)}"`)
     }
 
     public static async show(key: string): Promise<string> {

--- a/test/Gopass.test.ts
+++ b/test/Gopass.test.ts
@@ -58,7 +58,7 @@ describe('Gopass', () => {
 
             expect(ipcRendererSendSpy).toHaveBeenCalledWith('gopass', {
                 args: undefined,
-                command: 'show "some-secret-name" -c',
+                command: 'show -c "some-secret-name"',
                 executionId: 1,
                 pipeTextInto: undefined
             })


### PR DESCRIPTION
A typo in gopass.ts hinders copying passwords.

This PR fixes that.

Please squash the commits!