### PR TITLE
Fix edit secret with newer gopass

### DIFF
--- a/src/renderer/secrets/Gopass.ts
+++ b/src/renderer/secrets/Gopass.ts
@@ -57,7 +57,7 @@ export default class Gopass {
     }
 
     public static async editSecret(name: string, newValue: string): Promise<void> {
-        await Gopass.addSecret(name, newValue)
+        await Gopass.execute('insert', ['--force', `"${escapeShellValue(name.trim())}"`], escapeShellValue(newValue))
     }
 
     public static async deleteSecret(name: string): Promise<void> {


### PR DESCRIPTION
Simply added the `--force` flag as suggested in #72.
