### PR TITLE
Enhance the UI of the secrets tree

### DIFF
--- a/src/main/AppWindows.ts
+++ b/src/main/AppWindows.ts
@@ -1,8 +1,9 @@
-import { BrowserWindow, Menu, app } from 'electron'
+import { BrowserWindow, Menu, app, nativeTheme } from 'electron'
 import * as url from 'url'
 import * as path from 'path'
 
 export const createMainWindow = (): BrowserWindow => {
+    nativeTheme.themeSource = 'light'
     const mainWindow = new BrowserWindow({
         width: 1000,
         height: 600,

--- a/src/renderer/components/tree/TreeHeader.tsx
+++ b/src/renderer/components/tree/TreeHeader.tsx
@@ -11,7 +11,7 @@ export const TreeHeader = ({ style, node }: any) => {
         iconType = deriveIconFromSecretName(node.name)
     }
     return (
-        <div style={style.base}>
+        <div style={style.base} className='icon-wrapper'>
             {node.children && (
                 <div className={`chevron ${node.toggled && 'toggled'}`}>
                     <m.Icon small>chevron_right</m.Icon>

--- a/src/renderer/components/tree/TreeHeader.tsx
+++ b/src/renderer/components/tree/TreeHeader.tsx
@@ -4,14 +4,19 @@ import * as m from 'react-materialize'
 import { deriveIconFromSecretName } from '../../secrets/deriveIconFromSecretName'
 
 export const TreeHeader = ({ style, node }: any) => {
-    let iconType = node.toggled ? 'chevron_right' : 'folder'
+    let iconType = 'folder'
 
+    const isLeaf = !node.children && node.path
     if (!node.children && node.path) {
         iconType = deriveIconFromSecretName(node.name)
     }
-
     return (
         <div style={style.base}>
+            {node.children && (
+                <div className={`chevron ${node.toggled && 'toggled'}`}>
+                    <m.Icon small>chevron_right</m.Icon>
+                </div>
+            )}
             <m.Icon small>{iconType}</m.Icon>
 
             {node.name}

--- a/src/renderer/components/tree/TreeStyle.ts
+++ b/src/renderer/components/tree/TreeStyle.ts
@@ -15,8 +15,9 @@ export const globalStyle = {
         node: {
             base: {
                 position: 'relative',
-                marginLeft: '27px',
-                marginTop: '3px'
+                borderLeft: '1px solid #ececec',
+                padding: '4px 12px 4px',
+                marginLeft: '8px'
             },
             link: {
                 cursor: 'pointer',

--- a/src/renderer/explorer-app/ExplorerApplication.css
+++ b/src/renderer/explorer-app/ExplorerApplication.css
@@ -15,6 +15,10 @@
     padding: 0 8% !important;
 }
 
+.secret-explorer > ul > li {
+    border: 0;
+}
+
 .secret-explorer .chevron {
     display: inline-block;
     user-select: none;

--- a/src/renderer/explorer-app/ExplorerApplication.css
+++ b/src/renderer/explorer-app/ExplorerApplication.css
@@ -35,11 +35,11 @@
 }
 
 .link {
-    cursor: pointer
+    cursor: pointer;
 }
 
 span.code {
-    font-family: Consolas, monospace
+    font-family: Consolas, monospace;
 }
 
 .card-panel pre {

--- a/src/renderer/explorer-app/ExplorerApplication.css
+++ b/src/renderer/explorer-app/ExplorerApplication.css
@@ -17,10 +17,15 @@
 
 .secret-explorer .chevron {
     display: inline-block;
+    user-select: none;
 }
 
 .secret-explorer .chevron.toggled .material-icons {
     transform: rotate(90deg);
+}
+
+.secret-explorer .icon-wrapper > .material-icons:only-child {
+    margin-left: 30px;
 }
 
 .secret-explorer .chevron .material-icons {

--- a/src/renderer/explorer-app/ExplorerApplication.css
+++ b/src/renderer/explorer-app/ExplorerApplication.css
@@ -15,6 +15,18 @@
     padding: 0 8% !important;
 }
 
+.secret-explorer .chevron {
+    display: inline-block;
+}
+
+.secret-explorer .chevron.toggled .material-icons {
+    transform: rotate(90deg);
+}
+
+.secret-explorer .chevron .material-icons {
+    margin: 0;
+}
+
 .secret-explorer i.material-icons {
     position: relative;
     top: 7px;

--- a/src/renderer/explorer-app/ExplorerApplication.css
+++ b/src/renderer/explorer-app/ExplorerApplication.css
@@ -11,8 +11,25 @@
 }
 
 .secret-explorer .search-bar {
-    width: 84% !important;
-    padding: 0 8% !important;
+    background: #f9f9f9;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.14);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.secret-explorer .search-bar * {
+    margin: 0 !important;
+    border: none !important;
+}
+
+.secret-explorer .search-bar > div {
+    padding: 0 !important;
+}
+
+.secret-explorer .search-bar input {
+    box-sizing: border-box !important;
+    padding: 24px !important;
 }
 
 .secret-explorer > ul > li {

--- a/src/renderer/explorer-app/side-navigation/SecretExplorer.tsx
+++ b/src/renderer/explorer-app/side-navigation/SecretExplorer.tsx
@@ -18,14 +18,15 @@ const SecretExplorer = ({ history }: RouteComponentProps) => {
     return (
         <div className='secret-explorer'>
             <KeyboardEventHandler handleKeys={['esc']} handleFocusableElements onKeyEvent={clearSearch} />
-            <m.Input
-                className='search-bar'
-                value={searchValue}
-                placeholder='Search...'
-                onChange={(_: any, updatedSearchValue: string) => {
-                    applySearchToTree(updatedSearchValue)
-                }}
-            />
+            <div className='search-bar'>
+                <m.Input
+                    value={searchValue}
+                    placeholder='Search...'
+                    onChange={(_: any, updatedSearchValue: string) => {
+                        applySearchToTree(updatedSearchValue)
+                    }}
+                />
+            </div>
             <SecretTree tree={tree} onSecretClick={navigateToSecretDetailView} />
         </div>
     )


### PR DESCRIPTION
A UX improvements for the side secrets tree and the search input.
- Show both the folder and the chevron icons for better indication of the toggled nodes.
- Added line indicator for each tree level for better UX.
- Made the search bar sticky. 

Was:
<img width="389" alt="image" src="https://user-images.githubusercontent.com/7039768/166584842-ac45b054-b094-411a-81ee-8098ab63e965.png">

Now:
<img width="391" alt="image" src="https://user-images.githubusercontent.com/7039768/166584264-02e835b6-4d2a-4e78-92ea-cc578fbbe602.png">

I'm planning to contribute more but I thought let me start light!